### PR TITLE
[Update] NormalizeWordPress: Set post content to false if empty.

### DIFF
--- a/dist/lib/wp/normalizeWordpress.js
+++ b/dist/lib/wp/normalizeWordpress.js
@@ -15,6 +15,6 @@ function normalizeWordpress(data) {
 
 function _normalizeWordpressPost(post) {
   if (post.title && post.title.rendered) post.title = post.title.rendered;
-  if (post.content && post.content.rendered) post.content = post.content.rendered;
+  post.content = post.content && post.content.rendered ? post.content.rendered : false;
   return post;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wearelucid/api-fetcher",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Generates multiple JSON files from fetching API endpoints (i18n supported) 🚀",
   "main": "dist/index.js",
   "repository": "https://github.com/wearelucid/api-fetcher.git",

--- a/src/lib/wp/normalizeWordpress.js
+++ b/src/lib/wp/normalizeWordpress.js
@@ -6,6 +6,6 @@ export default function normalizeWordpress (data) {
 
 function _normalizeWordpressPost (post) {
   if (post.title && post.title.rendered) post.title = post.title.rendered
-  if (post.content && post.content.rendered) post.content = post.content.rendered
+  post.content = post.content && post.content.rendered ? post.content.rendered : false
   return post
 }


### PR DESCRIPTION
When normalizing a post with an empty content we will get something like this:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/7059580/51245457-02849200-1988-11e9-8939-469624eeefe5.png">

So setting it to false is better.
Agree?
If yes I will merge and publish to npm